### PR TITLE
Dev

### DIFF
--- a/goheader.go
+++ b/goheader.go
@@ -549,9 +549,14 @@ type Header struct {
 func NewHeaders(headers ...Header) http.Header {
 	header := http.Header{}
 	for _, h := range headers {
-		header[http.CanonicalHeaderKey(h.Name)] = h.Values
+		appendHeaderValues(header, h)
 	}
 	return header
+}
+
+func appendHeaderValues(dst http.Header, header Header) {
+	key := http.CanonicalHeaderKey(header.Name)
+	dst[key] = append(dst[key], header.Values...)
 }
 
 // AIMValue represents one A-IM token with optional quality and extensions.
@@ -6713,6 +6718,6 @@ func NewXXSSProtectionHeader(cfg XXSSProtectionConfig) Header {
 func WriteHeaders(writer interface{ Header() http.Header }, headers ...Header) {
 	writerHeaders := writer.Header()
 	for _, header := range headers {
-		writerHeaders[header.Name] = header.Values
+		appendHeaderValues(writerHeaders, header)
 	}
 }

--- a/goheader_test.go
+++ b/goheader_test.go
@@ -1,6 +1,8 @@
 package goheader_test
 
 import (
+	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/lindsaygelle/goheader"
@@ -1363,5 +1365,35 @@ func TestNewXXSSProtectionHeader(t *testing.T) {
 	h := goheader.NewXXSSProtectionHeader(cfg)
 	if h.Name != goheader.XXSSProtection {
 		t.Errorf("expected header name for XXSSProtection")
+	}
+}
+
+func TestNewHeadersAppendsDuplicateValues(t *testing.T) {
+	headers := goheader.NewHeaders(
+		goheader.NewSetCookieHeader(goheader.SetCookieConfig{Name: "a", Value: "1"}),
+		goheader.NewSetCookieHeader(goheader.SetCookieConfig{Name: "b", Value: "2"}),
+	)
+
+	want := []string{"a=1", "b=2"}
+	if !reflect.DeepEqual(headers.Values(goheader.SetCookie), want) {
+		t.Fatalf("expected %v, got %v", want, headers.Values(goheader.SetCookie))
+	}
+}
+
+func TestWriteHeadersAppendsDuplicateValuesAndCanonicalizesKeys(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	goheader.WriteHeaders(recorder,
+		goheader.Header{Name: "content-type", Values: []string{"text/plain"}},
+		goheader.Header{Name: "Content-Type", Values: []string{"application/json"}},
+	)
+
+	want := []string{"text/plain", "application/json"}
+	if !reflect.DeepEqual(recorder.Header().Values(goheader.ContentType), want) {
+		t.Fatalf("expected %v, got %v", want, recorder.Header().Values(goheader.ContentType))
+	}
+
+	if _, ok := recorder.Header()["content-type"]; ok {
+		t.Fatalf("expected lowercase content-type key to be canonicalized away, got %v", recorder.Header())
 	}
 }


### PR DESCRIPTION
## Summary
- preserve duplicate header values in both NewHeaders and WriteHeaders instead of overwriting earlier entries
- canonicalize header names through the shared append path so repeated keys land in the same http.Header entry
- add regression tests covering duplicate Set-Cookie handling and WriteHeaders key canonicalization

## Validation
- /usr/local/go/bin/go test ./...
- pre-commit run --all-files