### PR TITLE
Dev

### DIFF
--- a/goheader.go
+++ b/goheader.go
@@ -549,9 +549,14 @@ type Header struct {
 func NewHeaders(headers ...Header) http.Header {
 	header := http.Header{}
 	for _, h := range headers {
-		header[http.CanonicalHeaderKey(h.Name)] = h.Values
+		appendHeaderValues(header, h)
 	}
 	return header
+}
+
+func appendHeaderValues(dst http.Header, header Header) {
+	key := http.CanonicalHeaderKey(header.Name)
+	dst[key] = append(dst[key], header.Values...)
 }
 
 // AIMValue represents one A-IM token with optional quality and extensions.
@@ -6713,6 +6718,6 @@ func NewXXSSProtectionHeader(cfg XXSSProtectionConfig) Header {
 func WriteHeaders(writer interface{ Header() http.Header }, headers ...Header) {
 	writerHeaders := writer.Header()
 	for _, header := range headers {
-		writerHeaders[header.Name] = header.Values
+		appendHeaderValues(writerHeaders, header)
 	}
 }

--- a/goheader.go
+++ b/goheader.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 )
@@ -559,6 +560,23 @@ func appendHeaderValues(dst http.Header, header Header) {
 	dst[key] = append(dst[key], header.Values...)
 }
 
+func sortedMapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func joinStringMap(values map[string]string, sep string, format func(string, string) string) string {
+	parts := make([]string, 0, len(values))
+	for _, key := range sortedMapKeys(values) {
+		parts = append(parts, format(key, values[key]))
+	}
+	return strings.Join(parts, sep)
+}
+
 // AIMValue represents one A-IM token with optional quality and extensions.
 type AIMValue struct {
 	Token      string   // The instance manipulation name (e.g., "gzip", "vcdiff")
@@ -633,11 +651,9 @@ func (v AcceptValue) String() string {
 	result := v.MediaType
 
 	if len(v.Params) > 0 {
-		var params []string
-		for k, val := range v.Params {
-			params = append(params, fmt.Sprintf("%s=%s", k, val))
-		}
-		result += ";" + strings.Join(params, ";")
+		result += ";" + joinStringMap(v.Params, ";", func(key, value string) string {
+			return fmt.Sprintf("%s=%s", key, value)
+		})
 	}
 
 	if v.Quality > 0 && v.Quality < 1 {
@@ -986,11 +1002,9 @@ type AcceptPatchValue struct {
 func (v AcceptPatchValue) String() string {
 	result := v.MediaType
 	if len(v.Params) > 0 {
-		var params []string
-		for k, val := range v.Params {
-			params = append(params, fmt.Sprintf("%s=%s", k, val))
-		}
-		result += ";" + strings.Join(params, ";")
+		result += ";" + joinStringMap(v.Params, ";", func(key, value string) string {
+			return fmt.Sprintf("%s=%s", key, value)
+		})
 	}
 	return result
 }
@@ -1044,11 +1058,9 @@ type AcceptPostValue struct {
 func (v AcceptPostValue) String() string {
 	result := v.MediaType
 	if len(v.Params) > 0 {
-		var params []string
-		for k, val := range v.Params {
-			params = append(params, fmt.Sprintf("%s=%s", k, val))
-		}
-		result += ";" + strings.Join(params, ";")
+		result += ";" + joinStringMap(v.Params, ";", func(key, value string) string {
+			return fmt.Sprintf("%s=%s", key, value)
+		})
 	}
 	return result
 }
@@ -1870,11 +1882,9 @@ type ContentDispositionConfig struct {
 func (cfg ContentDispositionConfig) String() string {
 	result := cfg.Type
 	if len(cfg.Params) > 0 {
-		var parts []string
-		for k, v := range cfg.Params {
-			parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
-		}
-		result += "; " + strings.Join(parts, "; ")
+		result += "; " + joinStringMap(cfg.Params, "; ", func(key, value string) string {
+			return fmt.Sprintf(`%s="%s"`, key, value)
+		})
 	}
 	return result
 }
@@ -2248,11 +2258,9 @@ type ContentTypeConfig struct {
 func (cfg ContentTypeConfig) String() string {
 	result := cfg.MediaType
 	if len(cfg.Params) > 0 {
-		var params []string
-		for k, v := range cfg.Params {
-			params = append(params, fmt.Sprintf("%s=%s", k, v))
-		}
-		result += "; " + strings.Join(params, "; ")
+		result += "; " + joinStringMap(cfg.Params, "; ", func(key, value string) string {
+			return fmt.Sprintf("%s=%s", key, value)
+		})
 	}
 	return result
 }
@@ -3366,8 +3374,8 @@ type LinkEntry struct {
 func (e LinkEntry) String() string {
 	var parts []string
 	parts = append(parts, fmt.Sprintf("<%s>", e.URL))
-	for k, v := range e.Attributes {
-		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
+	for _, key := range sortedMapKeys(e.Attributes) {
+		parts = append(parts, fmt.Sprintf(`%s="%s"`, key, e.Attributes[key]))
 	}
 	return strings.Join(parts, "; ")
 }
@@ -3569,7 +3577,8 @@ type PermissionsPolicyConfig struct {
 // String renders the Permissions-Policy header value.
 func (cfg PermissionsPolicyConfig) String() string {
 	var parts []string
-	for feature, origins := range cfg.Directives {
+	for _, feature := range sortedMapKeys(cfg.Directives) {
+		origins := cfg.Directives[feature]
 		if len(origins) == 0 {
 			parts = append(parts, fmt.Sprintf("%s=()", feature))
 		} else {
@@ -3769,11 +3778,9 @@ type ProxyAuthenticationInfoConfig struct {
 
 // String renders the Proxy-Authentication-Info header value.
 func (cfg ProxyAuthenticationInfoConfig) String() string {
-	var parts []string
-	for k, v := range cfg.Params {
-		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Params, ", ", func(key, value string) string {
+		return fmt.Sprintf(`%s="%s"`, key, value)
+	})
 }
 
 // NewProxyAuthenticationInfoHeader creates a new Proxy-Authentication-Info header from the config.
@@ -4225,11 +4232,9 @@ type ReportingEndpointsConfig struct {
 
 // String renders the Reporting-Endpoints header value.
 func (cfg ReportingEndpointsConfig) String() string {
-	var parts []string
-	for name, url := range cfg.Endpoints {
-		parts = append(parts, fmt.Sprintf(`%s="%s"`, name, url))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Endpoints, ", ", func(key, value string) string {
+		return fmt.Sprintf(`%s="%s"`, key, value)
+	})
 }
 
 // NewReportingEndpointsHeader creates a new Reporting-Endpoints header from the config.
@@ -4421,11 +4426,9 @@ type SecCHUAConfig struct {
 
 // String renders the Sec-CH-UA header value.
 func (cfg SecCHUAConfig) String() string {
-	var parts []string
-	for brand, version := range cfg.Brands {
-		parts = append(parts, fmt.Sprintf(`"%s";v="%s"`, brand, version))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Brands, ", ", func(key, value string) string {
+		return fmt.Sprintf(`"%s";v="%s"`, key, value)
+	})
 }
 
 // NewSecCHUAHeader creates a new Sec-CH-UA header from the config.
@@ -4518,11 +4521,9 @@ type SecCHUAFullVersionConfig struct {
 
 // String renders the Sec-CH-UA-Full-Version header value.
 func (cfg SecCHUAFullVersionConfig) String() string {
-	var parts []string
-	for brand, version := range cfg.Brands {
-		parts = append(parts, fmt.Sprintf(`"%s";v="%s"`, brand, version))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Brands, ", ", func(key, value string) string {
+		return fmt.Sprintf(`"%s";v="%s"`, key, value)
+	})
 }
 
 // NewSecCHUAFullVersionHeader creates a new Sec-CH-UA-Full-Version header from the config.
@@ -4554,11 +4555,9 @@ type SecCHUAFullVersionListConfig struct {
 
 // String renders the Sec-CH-UA-Full-Version-List header value.
 func (cfg SecCHUAFullVersionListConfig) String() string {
-	var parts []string
-	for brand, version := range cfg.Brands {
-		parts = append(parts, fmt.Sprintf(`"%s";v="%s"`, brand, version))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Brands, ", ", func(key, value string) string {
+		return fmt.Sprintf(`"%s";v="%s"`, key, value)
+	})
 }
 
 // NewSecCHUAFullVersionListHeader creates a new Sec-CH-UA-Full-Version-List header from the config.

--- a/goheader_test.go
+++ b/goheader_test.go
@@ -1,6 +1,8 @@
 package goheader_test
 
 import (
+	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/lindsaygelle/goheader"
@@ -1363,5 +1365,35 @@ func TestNewXXSSProtectionHeader(t *testing.T) {
 	h := goheader.NewXXSSProtectionHeader(cfg)
 	if h.Name != goheader.XXSSProtection {
 		t.Errorf("expected header name for XXSSProtection")
+	}
+}
+
+func TestNewHeadersAppendsDuplicateValues(t *testing.T) {
+	headers := goheader.NewHeaders(
+		goheader.NewSetCookieHeader(goheader.SetCookieConfig{Name: "a", Value: "1"}),
+		goheader.NewSetCookieHeader(goheader.SetCookieConfig{Name: "b", Value: "2"}),
+	)
+
+	want := []string{"a=1", "b=2"}
+	if !reflect.DeepEqual(headers.Values(goheader.SetCookie), want) {
+		t.Fatalf("expected %v, got %v", want, headers.Values(goheader.SetCookie))
+	}
+}
+
+func TestWriteHeadersAppendsDuplicateValuesAndCanonicalizesKeys(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	goheader.WriteHeaders(recorder,
+		goheader.Header{Name: "content-type", Values: []string{"text/plain"}},
+		goheader.Header{Name: "Content-Type", Values: []string{"application/json"}},
+	)
+
+	want := []string{"text/plain", "application/json"}
+	if !reflect.DeepEqual(recorder.Header().Values(goheader.ContentType), want) {
+		t.Fatalf("expected %v, got %v", want, recorder.Header().Values(goheader.ContentType))
+	}
+
+	if _, ok := recorder.Header()["content-type"]; ok {
+		t.Fatalf("expected lowercase content-type key to be canonicalized away, got %v", recorder.Header())
 	}
 }

--- a/goheader_test.go
+++ b/goheader_test.go
@@ -1397,3 +1397,113 @@ func TestWriteHeadersAppendsDuplicateValuesAndCanonicalizesKeys(t *testing.T) {
 		t.Fatalf("expected lowercase content-type key to be canonicalized away, got %v", recorder.Header())
 	}
 }
+
+func TestAcceptHeaderSortsParamsDeterministically(t *testing.T) {
+	header := goheader.NewAcceptHeader(goheader.AcceptConfig{
+		Values: []goheader.AcceptValue{
+			{
+				MediaType: "text/html",
+				Params: map[string]string{
+					"version": "2",
+					"charset": "utf-8",
+				},
+				Quality: 0.8,
+			},
+		},
+	})
+
+	want := []string{"text/html;charset=utf-8;version=2;q=0.8"}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestContentDispositionHeaderSortsParamsDeterministically(t *testing.T) {
+	header := goheader.NewContentDispositionHeader(goheader.ContentDispositionConfig{
+		Type: "attachment",
+		Params: map[string]string{
+			"filename": "report.csv",
+			"size":     "123",
+		},
+	})
+
+	want := []string{`attachment; filename="report.csv"; size="123"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestLinkHeaderSortsAttributesDeterministically(t *testing.T) {
+	header := goheader.NewLinkHeader(goheader.LinkConfig{
+		Links: []goheader.LinkEntry{
+			{
+				URL: "https://example.com/page",
+				Attributes: map[string]string{
+					"title": "Page",
+					"rel":   "next",
+				},
+			},
+		},
+	})
+
+	want := []string{`<https://example.com/page>; rel="next"; title="Page"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestPermissionsPolicyHeaderSortsDirectivesDeterministically(t *testing.T) {
+	header := goheader.NewPermissionsPolicyHeader(goheader.PermissionsPolicyConfig{
+		Directives: map[string][]string{
+			"microphone":  {},
+			"geolocation": {"self"},
+		},
+	})
+
+	want := []string{"geolocation=(self), microphone=()"}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestProxyAuthenticationInfoHeaderSortsParamsDeterministically(t *testing.T) {
+	header := goheader.NewProxyAuthenticationInfoHeader(goheader.ProxyAuthenticationInfoConfig{
+		Params: map[string]string{
+			"qop":       "auth",
+			"nextnonce": "abc123",
+		},
+	})
+
+	want := []string{`nextnonce="abc123", qop="auth"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestReportingEndpointsHeaderSortsEndpointsDeterministically(t *testing.T) {
+	header := goheader.NewReportingEndpointsHeader(goheader.ReportingEndpointsConfig{
+		Endpoints: map[string]string{
+			"csp":     "https://example.com/csp-reports",
+			"default": "https://example.com/reports",
+		},
+	})
+
+	want := []string{`csp="https://example.com/csp-reports", default="https://example.com/reports"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestSecCHUAHeaderSortsBrandsDeterministically(t *testing.T) {
+	header := goheader.NewSecCHUAHeader(goheader.SecCHUAConfig{
+		Brands: map[string]string{
+			"Google Chrome": "112",
+			"Chromium":      "112",
+		},
+	})
+
+	want := []string{`"Chromium";v="112", "Google Chrome";v="112"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}


### PR DESCRIPTION
## Summary
- make map-backed header renderers deterministic by sorting keys before formatting params, attributes, directives, endpoints, and brand/version pairs
- centralize the sorted string-map join logic so the ordering fix is applied consistently across builders
- add regression tests covering deterministic output for representative public headers

## Validation
- /usr/local/go/bin/go test ./...
- pre-commit run --all-files