### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ And many more.
 ### Correct formatting out of the box
 Constructors handle the fiddly bits—q-values, date formatting (Mon, 02 Jan 2006 15:04:05 GMT), CSV joins, params quoting, and directive assembly.
 Examples:
-- `NewAcceptEncodingHeader(AcceptEncodingConfig{...})` > `"gzip;q=1.0, br;q=0.8"`
+- `NewAcceptEncodingHeader(AcceptEncodingConfig{...})` > `"gzip, br;q=0.8"`
 - `NewContentRangeHeader(ContentRangeConfig{...})` > `"bytes 0-499/1234"`
 - `NewRefreshHeader(RefreshConfig{...})` > `"5; url=https://example.com/new-page"`
 

--- a/doc.go
+++ b/doc.go
@@ -47,7 +47,7 @@
 //
 //	// Build a concrete http.Header map.
 //	h := goheader.NewHeaders(accept, ct)
-//	// Example: map[Accept:[application/json;q=1.0, text/html;charset=utf-8;q=0.8]
+//	// Example: map[Accept:[application/json, text/html;charset=utf-8;q=0.8]
 //	//            Content-Type:[application/json; charset=UTF-8]]
 //
 // Common builders

--- a/example_test.go
+++ b/example_test.go
@@ -75,7 +75,7 @@ func ExampleNewAcceptCharsetHeader() {
 		},
 	}
 	header := goheader.NewAcceptCharsetHeader(cfg)
-	fmt.Println(header.Values) // ["utf-8;q=1.0, iso-8859-1;q=0.5"]
+	fmt.Println(header.Values) // ["utf-8, iso-8859-1;q=0.5"]
 }
 
 // ExampleNewAcceptDatetimeHeader is an example function for NewAcceptDatetimeHeader.
@@ -98,7 +98,7 @@ func ExampleNewAcceptEncodingHeader() {
 		},
 	}
 	header := goheader.NewAcceptEncodingHeader(cfg)
-	fmt.Println(header.Values) // ["gzip;q=1.0, br;q=0.8"]
+	fmt.Println(header.Values) // ["gzip, br;q=0.8"]
 }
 
 // ExampleNewAcceptLanguageHeader is an example function for NewAcceptLanguageHeader.
@@ -111,7 +111,7 @@ func ExampleNewAcceptLanguageHeader() {
 		},
 	}
 	header := goheader.NewAcceptLanguageHeader(cfg)
-	fmt.Println(header.Values) // ["en-US;q=1.0, fr;q=0.8"]
+	fmt.Println(header.Values) // ["en-US, fr;q=0.8"]
 }
 
 // ExampleNewAcceptPatchHeader is an example function for NewAcceptPatchHeader.

--- a/example_test.go
+++ b/example_test.go
@@ -513,15 +513,17 @@ func ExampleNewDPRHeader() {
 	// Create a new goheader.Header instance.
 	cfg := goheader.DPRConfig{Value: 2.0}
 	header := goheader.NewDPRHeader(cfg)
-	fmt.Println(header.Values) // ["2.0"])
+	fmt.Println(header.Values) // ["2.0"]
 }
 
 // ExampleNewDateHeader is an example function for NewDateHeader.
 func ExampleNewDateHeader() {
 	// Create a new goheader.Header instance.
-	cfg := goheader.DateConfig{Time: time.Now()}
+	cfg := goheader.DateConfig{Time: time.Date(2025, time.September, 15, 15, 4, 5, 0, time.UTC)}
 	header := goheader.NewDateHeader(cfg)
-	fmt.Println(header.Values) // ["Mon, 02 Jan 2006 15:04:05 GMT"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// Mon, 15 Sep 2025 15:04:05 GMT
 }
 
 // ExampleNewDeltaBaseHeader is an example function for NewDeltaBaseHeader.
@@ -603,9 +605,11 @@ func ExampleNewExpectCTHeader() {
 // ExampleNewExpiresHeader is an example function for NewExpiresHeader.
 func ExampleNewExpiresHeader() {
 	// Create a new goheader.Header instance.
-	cfg := goheader.ExpiresConfig{Time: time.Now().Add(24 * time.Hour)}
+	cfg := goheader.ExpiresConfig{Time: time.Date(2025, time.September, 16, 15, 4, 5, 0, time.UTC)}
 	header := goheader.NewExpiresHeader(cfg)
-	fmt.Println(header.Values) // ["Wed, 21 Oct 2015 07:28:00 GMT"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// Tue, 16 Sep 2025 15:04:05 GMT
 }
 
 // ExampleNewForwardedHeader is an example function for NewForwardedHeader.
@@ -672,9 +676,11 @@ func ExampleNewIfMatchHeader() {
 // ExampleNewIfModifiedSinceHeader is an example function for NewIfModifiedSinceHeader.
 func ExampleNewIfModifiedSinceHeader() {
 	// Create a new goheader.Header instance.
-	cfg := goheader.IfModifiedSinceConfig{Time: time.Now().Add(-24 * time.Hour)}
+	cfg := goheader.IfModifiedSinceConfig{Time: time.Date(2025, time.September, 15, 15, 4, 5, 0, time.UTC)}
 	header := goheader.NewIfModifiedSinceHeader(cfg)
-	fmt.Println(header.Values) // ["Wed, 21 Oct 2015 07:28:00 GMT"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// Mon, 15 Sep 2025 15:04:05 GMT
 }
 
 // ExampleNewIfNoneMatchHeader is an example function for NewIfNoneMatchHeader.
@@ -696,9 +702,11 @@ func ExampleNewIfRangeHeader() {
 // ExampleNewIfUnmodifiedSinceHeader is an example function for NewIfUnmodifiedSinceHeader.
 func ExampleNewIfUnmodifiedSinceHeader() {
 	// Create a new goheader.Header instance.
-	cfg := goheader.IfUnmodifiedSinceConfig{Time: time.Now().Add(-24 * time.Hour)}
+	cfg := goheader.IfUnmodifiedSinceConfig{Time: time.Date(2025, time.September, 15, 15, 4, 5, 0, time.UTC)}
 	header := goheader.NewIfUnmodifiedSinceHeader(cfg)
-	fmt.Println(header.Values) // ["Wed, 21 Oct 2015 07:28:00 GMT"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// Mon, 15 Sep 2025 15:04:05 GMT
 }
 
 // ExampleNewKeepAliveHeader is an example function for NewKeepAliveHeader.
@@ -720,9 +728,11 @@ func ExampleNewLargeAllocationHeader() {
 // ExampleNewLastModifiedHeader is an example function for NewLastModifiedHeader.
 func ExampleNewLastModifiedHeader() {
 	// Create a new goheader.Header instance.
-	cfg := goheader.LastModifiedConfig{Time: time.Now().Add(-48 * time.Hour)}
+	cfg := goheader.LastModifiedConfig{Time: time.Date(2025, time.September, 14, 15, 4, 5, 0, time.UTC)}
 	header := goheader.NewLastModifiedHeader(cfg)
-	fmt.Println(header.Values) // ["Wed, 21 Oct 2015 07:28:00 GMT"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// Sun, 14 Sep 2025 15:04:05 GMT
 }
 
 // ExampleNewLinkHeader is an example function for NewLinkHeader.
@@ -1091,7 +1101,7 @@ func ExampleNewSecCHUAPlatformVersionHeader() {
 	fmt.Println(header.Values) // ["\"15.4\""]
 }
 
-// ExampleNewSecCHUAPlatformVersionHeader is an example function for NewSecCHUAWoW64Header.
+// ExampleNewSecCHUAWoW64Header is an example function for NewSecCHUAWoW64Header.
 func ExampleNewSecCHUAWoW64Header() {
 	// Create a new goheader.Header instance.
 	cfg := goheader.SecCHUAWoW64Config{WoW64: true}

--- a/example_test.go
+++ b/example_test.go
@@ -2,10 +2,8 @@
 package goheader_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
-	"net/http"
+	"net/http/httptest"
 	"time"
 
 	"github.com/lindsaygelle/goheader"
@@ -14,6 +12,21 @@ import (
 // ExampleNewAIMHeader is an example function for NewAIMHeader.
 func ExampleNewAIMHeader() {
 	// Create a new goheader.Header instance.
+	cfg := goheader.AIMConfig{
+		Values: []goheader.AIMValue{
+			{Token: "gzip", Quality: 1.0},
+			{Token: "vcdiff", Quality: 0.5, Extensions: []string{"custom=1"}},
+		},
+	}
+	header := goheader.NewAIMHeader(cfg)
+	fmt.Println(header.Values[0])
+	// Output:
+	// gzip;q=1.0, vcdiff;q=0.5;custom=1
+}
+
+// ExampleNewAcceptHeader is an example function for NewAcceptHeader.
+func ExampleNewAcceptHeader() {
+	// Create a new goheader.Header instance.
 	cfg := goheader.AcceptConfig{
 		Values: []goheader.AcceptValue{
 			{MediaType: "application/json", Quality: 1.0},
@@ -21,11 +34,13 @@ func ExampleNewAIMHeader() {
 		},
 	}
 	header := goheader.NewAcceptHeader(cfg)
-	fmt.Println(header.Values) // ["application/json;q=1.0, text/html;charset=utf-8;q=0.8"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// application/json, text/html;charset=utf-8;q=0.8
 }
 
-// ExampleNewAcceptHeader is an example function for NewAcceptHeader.
-func ExampleNewAcceptHeader() {
+// ExampleNewAcceptCHHeader is an example function for NewAcceptCHHeader.
+func ExampleNewAcceptCHHeader() {
 	// Create a new goheader.Header instance.
 	cfg := goheader.AcceptCHConfig{
 		Values: []goheader.AcceptCHValue{
@@ -34,15 +49,9 @@ func ExampleNewAcceptHeader() {
 		},
 	}
 	header := goheader.NewAcceptCHHeader(cfg)
-	fmt.Println(header.Values) // ["DPR, Viewport-Width"]
-}
-
-// ExampleNewAcceptCHHeader is an example function for NewAcceptCHHeader.
-func ExampleNewAcceptCHHeader() {
-	// Create a new goheader.Header instance.
-	cfg := goheader.AcceptCHLifetimeConfig{Lifetime: 86400}
-	header := goheader.NewAcceptCHLifetimeHeader(cfg)
-	fmt.Println(header.Values) // ["86400"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// DPR, Viewport-Width
 }
 
 // ExampleNewAcceptCHLifetimeHeader is an example function for NewAcceptCHLifetimeHeader.
@@ -50,7 +59,9 @@ func ExampleNewAcceptCHLifetimeHeader() {
 	// Create a new goheader.Header instance.
 	cfg := goheader.AcceptCHLifetimeConfig{Lifetime: 86400}
 	header := goheader.NewAcceptCHLifetimeHeader(cfg)
-	fmt.Println(header.Values) // ["86400"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// 86400
 }
 
 // ExampleNewAcceptCharsetHeader is an example function for NewAcceptCharsetHeader.
@@ -431,7 +442,9 @@ func ExampleNewContentTypeHeader() {
 		Params:    map[string]string{"charset": "UTF-8"},
 	}
 	header := goheader.NewContentTypeHeader(cfg)
-	fmt.Println(header.Values) // ["application/json; charset=UTF-8"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// application/json; charset=UTF-8
 }
 
 // ExampleNewCookieHeader is an example function for NewCookieHeader.
@@ -1200,13 +1213,15 @@ func ExampleNewServiceWorkerNavigationPreloadHeader() {
 // ExampleNewSetCookieHeader is an example function for NewSetCookieHeader.
 func ExampleNewSetCookieHeader() {
 	// Create a new goheader.Header instance.
-	expires := time.Now().Add(24 * time.Hour)
+	expires := time.Date(2025, time.September, 16, 15, 4, 5, 0, time.UTC)
 	cfg := goheader.SetCookieConfig{
 		Name: "sessionId", Value: "abc123", Expires: &expires,
 		Path: "/", Secure: true, HTTPOnly: true, SameSite: "Strict",
 	}
 	header := goheader.NewSetCookieHeader(cfg)
-	fmt.Println(header.Values) // ["sessionId=abc123; Expires=Mon, 16 Sep 2025 15:04:05 GMT; Path=/; Secure; HTTPOnly; SameSite=Strict"]
+	fmt.Println(header.Values[0])
+	// Output:
+	// sessionId=abc123; Expires=Tue, 16 Sep 2025 15:04:05 GMT; Path=/; Secure; HttpOnly; SameSite=Strict
 }
 
 // ExampleNewSourceMapHeader is an example function for NewSourceMapHeader.
@@ -1575,45 +1590,31 @@ func ExampleNewXXSSProtectionHeader() {
 
 // ExampleWriteHeaders is an example function for WriteHeaders.
 func ExampleWriteHeaders() {
-	// Create a default handler.
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// Create a new set of goheader.Header instances.
-		headers := []goheader.Header{
-			goheader.NewContentLanguageHeader(goheader.ContentLanguageConfig{
-				Values: []goheader.ContentLanguageValue{
-					goheader.ContentLanguageValue{
-						Language: "en",
-					},
-				},
-			}),
-			goheader.NewContentTypeHeader(goheader.ContentTypeConfig{
-				MediaType: "application/json",
-				Params: map[string]string{
-					"charset": "UTF-8",
-				},
-			}),
-			goheader.NewCookieHeader(goheader.CookieConfig{
-				Cookies: []goheader.CookieValue{
-					goheader.CookieValue{
-						Name:  "sessionId",
-						Value: "abc123",
-					},
-					goheader.CookieValue{
-						Name:  "theme",
-						Value: "dark"},
-				},
-			}),
-		}
+	recorder := httptest.NewRecorder()
+	headers := []goheader.Header{
+		goheader.NewContentLanguageHeader(goheader.ContentLanguageConfig{
+			Values: []goheader.ContentLanguageValue{
+				{Language: "en"},
+			},
+		}),
+		goheader.NewContentTypeHeader(goheader.ContentTypeConfig{
+			MediaType: "application/json",
+			Params:    map[string]string{"charset": "UTF-8"},
+		}),
+		goheader.NewSetCookieHeader(goheader.SetCookieConfig{
+			Name:  "sessionId",
+			Value: "abc123",
+			Path:  "/",
+		}),
+	}
 
-		// Add the headers to the http.ResponseWriter.
-		goheader.WriteHeaders(w, headers...)
-		// Write the HTTP status code.
-		w.WriteHeader(http.StatusOK)
-		// Write the HTTP response.
-		json.NewEncoder(w).Encode(w.Header())
-	})
-	// Set the port for the server.
-	serverAddress := fmt.Sprintf(":%d", 8080)
-	// Serve content.
-	log.Println(http.ListenAndServe(serverAddress, nil))
+	goheader.WriteHeaders(recorder, headers...)
+
+	fmt.Println(recorder.Header().Get(goheader.ContentLanguage))
+	fmt.Println(recorder.Header().Get(goheader.ContentType))
+	fmt.Println(recorder.Header().Values(goheader.SetCookie)[0])
+	// Output:
+	// en
+	// application/json; charset=UTF-8
+	// sessionId=abc123; Path=/
 }

--- a/goheader.go
+++ b/goheader.go
@@ -549,9 +549,14 @@ type Header struct {
 func NewHeaders(headers ...Header) http.Header {
 	header := http.Header{}
 	for _, h := range headers {
-		header[http.CanonicalHeaderKey(h.Name)] = h.Values
+		appendHeaderValues(header, h)
 	}
 	return header
+}
+
+func appendHeaderValues(dst http.Header, header Header) {
+	key := http.CanonicalHeaderKey(header.Name)
+	dst[key] = append(dst[key], header.Values...)
 }
 
 // AIMValue represents one A-IM token with optional quality and extensions.
@@ -6713,6 +6718,6 @@ func NewXXSSProtectionHeader(cfg XXSSProtectionConfig) Header {
 func WriteHeaders(writer interface{ Header() http.Header }, headers ...Header) {
 	writerHeaders := writer.Header()
 	for _, header := range headers {
-		writerHeaders[header.Name] = header.Values
+		appendHeaderValues(writerHeaders, header)
 	}
 }

--- a/goheader.go
+++ b/goheader.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 )
@@ -559,6 +560,23 @@ func appendHeaderValues(dst http.Header, header Header) {
 	dst[key] = append(dst[key], header.Values...)
 }
 
+func sortedMapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func joinStringMap(values map[string]string, sep string, format func(string, string) string) string {
+	parts := make([]string, 0, len(values))
+	for _, key := range sortedMapKeys(values) {
+		parts = append(parts, format(key, values[key]))
+	}
+	return strings.Join(parts, sep)
+}
+
 // AIMValue represents one A-IM token with optional quality and extensions.
 type AIMValue struct {
 	Token      string   // The instance manipulation name (e.g., "gzip", "vcdiff")
@@ -633,11 +651,9 @@ func (v AcceptValue) String() string {
 	result := v.MediaType
 
 	if len(v.Params) > 0 {
-		var params []string
-		for k, val := range v.Params {
-			params = append(params, fmt.Sprintf("%s=%s", k, val))
-		}
-		result += ";" + strings.Join(params, ";")
+		result += ";" + joinStringMap(v.Params, ";", func(key, value string) string {
+			return fmt.Sprintf("%s=%s", key, value)
+		})
 	}
 
 	if v.Quality > 0 && v.Quality < 1 {
@@ -986,11 +1002,9 @@ type AcceptPatchValue struct {
 func (v AcceptPatchValue) String() string {
 	result := v.MediaType
 	if len(v.Params) > 0 {
-		var params []string
-		for k, val := range v.Params {
-			params = append(params, fmt.Sprintf("%s=%s", k, val))
-		}
-		result += ";" + strings.Join(params, ";")
+		result += ";" + joinStringMap(v.Params, ";", func(key, value string) string {
+			return fmt.Sprintf("%s=%s", key, value)
+		})
 	}
 	return result
 }
@@ -1044,11 +1058,9 @@ type AcceptPostValue struct {
 func (v AcceptPostValue) String() string {
 	result := v.MediaType
 	if len(v.Params) > 0 {
-		var params []string
-		for k, val := range v.Params {
-			params = append(params, fmt.Sprintf("%s=%s", k, val))
-		}
-		result += ";" + strings.Join(params, ";")
+		result += ";" + joinStringMap(v.Params, ";", func(key, value string) string {
+			return fmt.Sprintf("%s=%s", key, value)
+		})
 	}
 	return result
 }
@@ -1870,11 +1882,9 @@ type ContentDispositionConfig struct {
 func (cfg ContentDispositionConfig) String() string {
 	result := cfg.Type
 	if len(cfg.Params) > 0 {
-		var parts []string
-		for k, v := range cfg.Params {
-			parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
-		}
-		result += "; " + strings.Join(parts, "; ")
+		result += "; " + joinStringMap(cfg.Params, "; ", func(key, value string) string {
+			return fmt.Sprintf(`%s="%s"`, key, value)
+		})
 	}
 	return result
 }
@@ -2248,11 +2258,9 @@ type ContentTypeConfig struct {
 func (cfg ContentTypeConfig) String() string {
 	result := cfg.MediaType
 	if len(cfg.Params) > 0 {
-		var params []string
-		for k, v := range cfg.Params {
-			params = append(params, fmt.Sprintf("%s=%s", k, v))
-		}
-		result += "; " + strings.Join(params, "; ")
+		result += "; " + joinStringMap(cfg.Params, "; ", func(key, value string) string {
+			return fmt.Sprintf("%s=%s", key, value)
+		})
 	}
 	return result
 }
@@ -3366,8 +3374,8 @@ type LinkEntry struct {
 func (e LinkEntry) String() string {
 	var parts []string
 	parts = append(parts, fmt.Sprintf("<%s>", e.URL))
-	for k, v := range e.Attributes {
-		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
+	for _, key := range sortedMapKeys(e.Attributes) {
+		parts = append(parts, fmt.Sprintf(`%s="%s"`, key, e.Attributes[key]))
 	}
 	return strings.Join(parts, "; ")
 }
@@ -3569,7 +3577,8 @@ type PermissionsPolicyConfig struct {
 // String renders the Permissions-Policy header value.
 func (cfg PermissionsPolicyConfig) String() string {
 	var parts []string
-	for feature, origins := range cfg.Directives {
+	for _, feature := range sortedMapKeys(cfg.Directives) {
+		origins := cfg.Directives[feature]
 		if len(origins) == 0 {
 			parts = append(parts, fmt.Sprintf("%s=()", feature))
 		} else {
@@ -3769,11 +3778,9 @@ type ProxyAuthenticationInfoConfig struct {
 
 // String renders the Proxy-Authentication-Info header value.
 func (cfg ProxyAuthenticationInfoConfig) String() string {
-	var parts []string
-	for k, v := range cfg.Params {
-		parts = append(parts, fmt.Sprintf(`%s="%s"`, k, v))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Params, ", ", func(key, value string) string {
+		return fmt.Sprintf(`%s="%s"`, key, value)
+	})
 }
 
 // NewProxyAuthenticationInfoHeader creates a new Proxy-Authentication-Info header from the config.
@@ -4225,11 +4232,9 @@ type ReportingEndpointsConfig struct {
 
 // String renders the Reporting-Endpoints header value.
 func (cfg ReportingEndpointsConfig) String() string {
-	var parts []string
-	for name, url := range cfg.Endpoints {
-		parts = append(parts, fmt.Sprintf(`%s="%s"`, name, url))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Endpoints, ", ", func(key, value string) string {
+		return fmt.Sprintf(`%s="%s"`, key, value)
+	})
 }
 
 // NewReportingEndpointsHeader creates a new Reporting-Endpoints header from the config.
@@ -4421,11 +4426,9 @@ type SecCHUAConfig struct {
 
 // String renders the Sec-CH-UA header value.
 func (cfg SecCHUAConfig) String() string {
-	var parts []string
-	for brand, version := range cfg.Brands {
-		parts = append(parts, fmt.Sprintf(`"%s";v="%s"`, brand, version))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Brands, ", ", func(key, value string) string {
+		return fmt.Sprintf(`"%s";v="%s"`, key, value)
+	})
 }
 
 // NewSecCHUAHeader creates a new Sec-CH-UA header from the config.
@@ -4518,11 +4521,9 @@ type SecCHUAFullVersionConfig struct {
 
 // String renders the Sec-CH-UA-Full-Version header value.
 func (cfg SecCHUAFullVersionConfig) String() string {
-	var parts []string
-	for brand, version := range cfg.Brands {
-		parts = append(parts, fmt.Sprintf(`"%s";v="%s"`, brand, version))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Brands, ", ", func(key, value string) string {
+		return fmt.Sprintf(`"%s";v="%s"`, key, value)
+	})
 }
 
 // NewSecCHUAFullVersionHeader creates a new Sec-CH-UA-Full-Version header from the config.
@@ -4554,11 +4555,9 @@ type SecCHUAFullVersionListConfig struct {
 
 // String renders the Sec-CH-UA-Full-Version-List header value.
 func (cfg SecCHUAFullVersionListConfig) String() string {
-	var parts []string
-	for brand, version := range cfg.Brands {
-		parts = append(parts, fmt.Sprintf(`"%s";v="%s"`, brand, version))
-	}
-	return strings.Join(parts, ", ")
+	return joinStringMap(cfg.Brands, ", ", func(key, value string) string {
+		return fmt.Sprintf(`"%s";v="%s"`, key, value)
+	})
 }
 
 // NewSecCHUAFullVersionListHeader creates a new Sec-CH-UA-Full-Version-List header from the config.

--- a/goheader.go
+++ b/goheader.go
@@ -690,7 +690,7 @@ func (cfg AcceptConfig) String() string {
 //	}
 //	header := goheader.NewAcceptHeader(cfg)
 //	fmt.Println(header.Name)   // Accept
-//	fmt.Println(header.Values) // ["application/json;q=1.0, text/html;charset=utf-8;q=0.8"]
+//	fmt.Println(header.Values) // ["application/json, text/html;charset=utf-8;q=0.8"]
 func NewAcceptHeader(cfg AcceptConfig) Header {
 	return Header{
 		Experimental: false,
@@ -831,7 +831,7 @@ func (cfg AcceptCharsetConfig) String() string {
 //	}
 //	header := goheader.NewAcceptCharsetHeader(cfg)
 //	fmt.Println(header.Name)   // Accept-Charset
-//	fmt.Println(header.Values) // ["utf-8;q=1.0, iso-8859-1;q=0.5"]
+//	fmt.Println(header.Values) // ["utf-8, iso-8859-1;q=0.5"]
 func NewAcceptCharsetHeader(cfg AcceptCharsetConfig) Header {
 	return Header{
 		Experimental: false,
@@ -922,7 +922,7 @@ func (cfg AcceptEncodingConfig) String() string {
 //	}
 //	header := goheader.NewAcceptEncodingHeader(cfg)
 //	fmt.Println(header.Name)   // Accept-Encoding
-//	fmt.Println(header.Values) // ["gzip;q=1.0, br;q=0.8"]
+//	fmt.Println(header.Values) // ["gzip, br;q=0.8"]
 func NewAcceptEncodingHeader(cfg AcceptEncodingConfig) Header {
 	return Header{
 		Experimental: false,
@@ -980,7 +980,7 @@ func (cfg AcceptLanguageConfig) String() string {
 //	}
 //	header := goheader.NewAcceptLanguageHeader(cfg)
 //	fmt.Println(header.Name)   // Accept-Language
-//	fmt.Println(header.Values) // ["en-US;q=1.0, fr;q=0.8"]
+//	fmt.Println(header.Values) // ["en-US, fr;q=0.8"]
 func NewAcceptLanguageHeader(cfg AcceptLanguageConfig) Header {
 	return Header{
 		Experimental: false,
@@ -5250,7 +5250,7 @@ func (cfg SetCookieConfig) String() string {
 //	}
 //	header := goheader.NewSetCookieHeader(cfg)
 //	fmt.Println(header.Name)   // Set-Cookie
-//	fmt.Println(header.Values) // ["sessionId=abc123; Expires=...; Path=/; Secure; HTTPOnly; SameSite=Strict"]
+//	fmt.Println(header.Values) // ["sessionId=abc123; Expires=...; Path=/; Secure; HttpOnly; SameSite=Strict"]
 func NewSetCookieHeader(cfg SetCookieConfig) Header {
 	return Header{
 		Experimental: false,

--- a/goheader_test.go
+++ b/goheader_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/lindsaygelle/goheader"
 )
@@ -17,10 +18,22 @@ func TestNewAIMHeader(t *testing.T) {
 }
 
 func TestNewAcceptHeader(t *testing.T) {
-	cfg := goheader.AcceptConfig{}
+	cfg := goheader.AcceptConfig{
+		Values: []goheader.AcceptValue{
+			{MediaType: "application/json", Quality: 1.0},
+			{MediaType: "text/html", Quality: 0.8, Params: map[string]string{"charset": "utf-8"}},
+		},
+	}
 	h := goheader.NewAcceptHeader(cfg)
 	if h.Name != goheader.Accept {
-		t.Errorf("expected header name for Accept")
+		t.Fatalf("expected header name %q, got %q", goheader.Accept, h.Name)
+	}
+	if !h.Request || h.Response || !h.Standard || h.Experimental {
+		t.Fatalf("unexpected Accept header metadata: %+v", h)
+	}
+	want := []string{"application/json, text/html;charset=utf-8;q=0.8"}
+	if !reflect.DeepEqual(h.Values, want) {
+		t.Fatalf("expected values %v, got %v", want, h.Values)
 	}
 }
 
@@ -201,10 +214,23 @@ func TestNewAuthorizationHeader(t *testing.T) {
 }
 
 func TestNewCacheControlHeader(t *testing.T) {
-	cfg := goheader.CacheControlConfig{}
+	maxAge := 3600
+	cfg := goheader.CacheControlConfig{
+		Directives: []goheader.CacheControlDirective{
+			{Directive: "max-age", Value: &maxAge},
+			{Directive: "no-cache"},
+		},
+	}
 	h := goheader.NewCacheControlHeader(cfg)
 	if h.Name != goheader.CacheControl {
-		t.Errorf("expected header name for CacheControl")
+		t.Fatalf("expected header name %q, got %q", goheader.CacheControl, h.Name)
+	}
+	if !h.Request || !h.Response || !h.Standard || h.Experimental {
+		t.Fatalf("unexpected Cache-Control header metadata: %+v", h)
+	}
+	want := []string{"max-age=3600, no-cache"}
+	if !reflect.DeepEqual(h.Values, want) {
+		t.Fatalf("expected values %v, got %v", want, h.Values)
 	}
 }
 
@@ -305,10 +331,20 @@ func TestNewContentSecurityPolicyReportOnlyHeader(t *testing.T) {
 }
 
 func TestNewContentTypeHeader(t *testing.T) {
-	cfg := goheader.ContentTypeConfig{}
+	cfg := goheader.ContentTypeConfig{
+		MediaType: "application/json",
+		Params:    map[string]string{"charset": "UTF-8"},
+	}
 	h := goheader.NewContentTypeHeader(cfg)
 	if h.Name != goheader.ContentType {
-		t.Errorf("expected header name for ContentType")
+		t.Fatalf("expected header name %q, got %q", goheader.ContentType, h.Name)
+	}
+	if !h.Request || !h.Response || !h.Standard || h.Experimental {
+		t.Fatalf("unexpected Content-Type header metadata: %+v", h)
+	}
+	want := []string{"application/json; charset=UTF-8"}
+	if !reflect.DeepEqual(h.Values, want) {
+		t.Fatalf("expected values %v, got %v", want, h.Values)
 	}
 }
 
@@ -1009,10 +1045,26 @@ func TestNewServiceWorkerNavigationPreloadHeader(t *testing.T) {
 }
 
 func TestNewSetCookieHeader(t *testing.T) {
-	cfg := goheader.SetCookieConfig{}
+	expires := time.Date(2025, time.September, 16, 15, 4, 5, 0, time.UTC)
+	cfg := goheader.SetCookieConfig{
+		Name:     "sessionId",
+		Value:    "abc123",
+		Expires:  &expires,
+		Path:     "/",
+		Secure:   true,
+		HTTPOnly: true,
+		SameSite: "Strict",
+	}
 	h := goheader.NewSetCookieHeader(cfg)
 	if h.Name != goheader.SetCookie {
-		t.Errorf("expected header name for SetCookie")
+		t.Fatalf("expected header name %q, got %q", goheader.SetCookie, h.Name)
+	}
+	if h.Request || !h.Response || !h.Standard || h.Experimental {
+		t.Fatalf("unexpected Set-Cookie header metadata: %+v", h)
+	}
+	want := []string{"sessionId=abc123; Expires=Tue, 16 Sep 2025 15:04:05 GMT; Path=/; Secure; HttpOnly; SameSite=Strict"}
+	if !reflect.DeepEqual(h.Values, want) {
+		t.Fatalf("expected values %v, got %v", want, h.Values)
 	}
 }
 
@@ -1033,10 +1085,21 @@ func TestNewStatusHeader(t *testing.T) {
 }
 
 func TestNewStrictTransportSecurityHeader(t *testing.T) {
-	cfg := goheader.StrictTransportSecurityConfig{}
+	cfg := goheader.StrictTransportSecurityConfig{
+		MaxAge:            31536000,
+		IncludeSubDomains: true,
+		Preload:           true,
+	}
 	h := goheader.NewStrictTransportSecurityHeader(cfg)
 	if h.Name != goheader.StrictTransportSecurity {
-		t.Errorf("expected header name for StrictTransportSecurity")
+		t.Fatalf("expected header name %q, got %q", goheader.StrictTransportSecurity, h.Name)
+	}
+	if h.Request || !h.Response || !h.Standard || h.Experimental {
+		t.Fatalf("unexpected Strict-Transport-Security header metadata: %+v", h)
+	}
+	want := []string{"max-age=31536000; includeSubDomains; preload"}
+	if !reflect.DeepEqual(h.Values, want) {
+		t.Fatalf("expected values %v, got %v", want, h.Values)
 	}
 }
 

--- a/goheader_test.go
+++ b/goheader_test.go
@@ -1,6 +1,8 @@
 package goheader_test
 
 import (
+	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/lindsaygelle/goheader"
@@ -1363,5 +1365,35 @@ func TestNewXXSSProtectionHeader(t *testing.T) {
 	h := goheader.NewXXSSProtectionHeader(cfg)
 	if h.Name != goheader.XXSSProtection {
 		t.Errorf("expected header name for XXSSProtection")
+	}
+}
+
+func TestNewHeadersAppendsDuplicateValues(t *testing.T) {
+	headers := goheader.NewHeaders(
+		goheader.NewSetCookieHeader(goheader.SetCookieConfig{Name: "a", Value: "1"}),
+		goheader.NewSetCookieHeader(goheader.SetCookieConfig{Name: "b", Value: "2"}),
+	)
+
+	want := []string{"a=1", "b=2"}
+	if !reflect.DeepEqual(headers.Values(goheader.SetCookie), want) {
+		t.Fatalf("expected %v, got %v", want, headers.Values(goheader.SetCookie))
+	}
+}
+
+func TestWriteHeadersAppendsDuplicateValuesAndCanonicalizesKeys(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	goheader.WriteHeaders(recorder,
+		goheader.Header{Name: "content-type", Values: []string{"text/plain"}},
+		goheader.Header{Name: "Content-Type", Values: []string{"application/json"}},
+	)
+
+	want := []string{"text/plain", "application/json"}
+	if !reflect.DeepEqual(recorder.Header().Values(goheader.ContentType), want) {
+		t.Fatalf("expected %v, got %v", want, recorder.Header().Values(goheader.ContentType))
+	}
+
+	if _, ok := recorder.Header()["content-type"]; ok {
+		t.Fatalf("expected lowercase content-type key to be canonicalized away, got %v", recorder.Header())
 	}
 }

--- a/goheader_test.go
+++ b/goheader_test.go
@@ -1397,3 +1397,113 @@ func TestWriteHeadersAppendsDuplicateValuesAndCanonicalizesKeys(t *testing.T) {
 		t.Fatalf("expected lowercase content-type key to be canonicalized away, got %v", recorder.Header())
 	}
 }
+
+func TestAcceptHeaderSortsParamsDeterministically(t *testing.T) {
+	header := goheader.NewAcceptHeader(goheader.AcceptConfig{
+		Values: []goheader.AcceptValue{
+			{
+				MediaType: "text/html",
+				Params: map[string]string{
+					"version": "2",
+					"charset": "utf-8",
+				},
+				Quality: 0.8,
+			},
+		},
+	})
+
+	want := []string{"text/html;charset=utf-8;version=2;q=0.8"}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestContentDispositionHeaderSortsParamsDeterministically(t *testing.T) {
+	header := goheader.NewContentDispositionHeader(goheader.ContentDispositionConfig{
+		Type: "attachment",
+		Params: map[string]string{
+			"filename": "report.csv",
+			"size":     "123",
+		},
+	})
+
+	want := []string{`attachment; filename="report.csv"; size="123"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestLinkHeaderSortsAttributesDeterministically(t *testing.T) {
+	header := goheader.NewLinkHeader(goheader.LinkConfig{
+		Links: []goheader.LinkEntry{
+			{
+				URL: "https://example.com/page",
+				Attributes: map[string]string{
+					"title": "Page",
+					"rel":   "next",
+				},
+			},
+		},
+	})
+
+	want := []string{`<https://example.com/page>; rel="next"; title="Page"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestPermissionsPolicyHeaderSortsDirectivesDeterministically(t *testing.T) {
+	header := goheader.NewPermissionsPolicyHeader(goheader.PermissionsPolicyConfig{
+		Directives: map[string][]string{
+			"microphone":  {},
+			"geolocation": {"self"},
+		},
+	})
+
+	want := []string{"geolocation=(self), microphone=()"}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestProxyAuthenticationInfoHeaderSortsParamsDeterministically(t *testing.T) {
+	header := goheader.NewProxyAuthenticationInfoHeader(goheader.ProxyAuthenticationInfoConfig{
+		Params: map[string]string{
+			"qop":       "auth",
+			"nextnonce": "abc123",
+		},
+	})
+
+	want := []string{`nextnonce="abc123", qop="auth"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestReportingEndpointsHeaderSortsEndpointsDeterministically(t *testing.T) {
+	header := goheader.NewReportingEndpointsHeader(goheader.ReportingEndpointsConfig{
+		Endpoints: map[string]string{
+			"csp":     "https://example.com/csp-reports",
+			"default": "https://example.com/reports",
+		},
+	})
+
+	want := []string{`csp="https://example.com/csp-reports", default="https://example.com/reports"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}
+
+func TestSecCHUAHeaderSortsBrandsDeterministically(t *testing.T) {
+	header := goheader.NewSecCHUAHeader(goheader.SecCHUAConfig{
+		Brands: map[string]string{
+			"Google Chrome": "112",
+			"Chromium":      "112",
+		},
+	})
+
+	want := []string{`"Chromium";v="112", "Google Chrome";v="112"`}
+	if !reflect.DeepEqual(header.Values, want) {
+		t.Fatalf("expected %v, got %v", want, header.Values)
+	}
+}


### PR DESCRIPTION
## Summary
- replace more date-based examples that used dynamic times with fixed timestamps and checked `// Output:` blocks
- make the example output reflect the real rendered values for Date, Expires, If-Modified-Since, If-Unmodified-Since, and Last-Modified
- clean up adjacent example typos in the DPR output comment and the Sec-CH-UA-WoW64 example doc comment

## Validation
- /usr/local/go/bin/go test ./...
- pre-commit run --all-files